### PR TITLE
Ignore lib folder for coverage estimation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ script:
     - export PERL5OPT=-MDevel::Cover=-coverage,statement,branch,condition,path,subroutine
     - travis_wait 60 prove -lrv test/chloroExtractor-testsuite/cmd_based/*.t
     - export PERL5OPT=""
-    - cover
+    - cover -ignore_re=lib
 after_success:
-    - cover -report coveralls
+    - cover -ignore_re=lib -report coveralls
 matrix:
     allow_failures:
        - perl: "5.8"


### PR DESCRIPTION
Lib folder content is not required to be considered for coverage estimation, due to it should be tested in their home repositories.