### PR TITLE
Add figure width

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -52,7 +52,7 @@ This is an automated pipeline that extracts and reconstructs chloroplast genomes
 It is capable to assemble the incidental sequenced chloropast DNA, which is present in almost all plant sequencing projects, due to the extraction of whole cellular DNA.
 It works by analyzing the k-mer distribution (determined with Jellyfish, [@marcais_fast_2011]) of the raw sequencing reads.
 Usually the coverage of the chloroplast genome is much higher than that of the nuclear genome.
-Using alignments to reference chloroplast sequences and the k-mer distribution candidate chloroplast reads are extracted from the complete set.
+Using alignments to reference chloroplast sequences and the k-mer distribution candidate chloroplast reads are extracted from the complete set (Figure 1).
 Afterwards, the targeted assembly of those sequences is much faster and yields less contigs compared to an assembly of all reads.
 Assemblers usually fail to assemble chloroplast genomes as a single contig due to their structure, consisting of two single copy regions and an inverted repeat.
 The size of the inverted repeat is in most cases multiple kilobasepairs in size, therefore it can not be resolved using short reads only.

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -13,6 +13,7 @@ authors:
  - name: Niklas Terhoeven
    affiliation: 2,3
  - name: Musga Qureischi
+   orcid: 0000-0001-9661-8494
    affiliation: 3,4
  - name: Maik Gündel
    orcid: 0000-0002-0502-4576

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -65,7 +65,7 @@ A similar tool, aiming the assembly of whole chloroplast genomes is the Python p
 Also plasmid SPAdes [@plasmidspades_2016] could possibly be used for this purpose although it is not intended for it.
 In the future, we plan to use our chloroExtractor to screen NCBI's Sequence Read Archive [@sra2011] for chloroplast genomes in public sequencing datasets that are not yet available in chloroplast databases, eg. chloroDB [@chlordb2006] to broaden our knowledge about chloroplasts.
 
-![Schematic workflow of chloroExtractor.](workflow.png)
+![Schematic workflow of chloroExtractor.](workflow.png){ width=70% }
 
 # Acknowledgements
 


### PR DESCRIPTION
The full width figure is too large.
This width attribute is ignored by github but used by pandoc
See: http://pandoc.org/MANUAL.html#images

Some other points that should be added to this pr:
 - [x] Maik name/affiliation
 - [ ] A reference to the figure from the text
 - [ ] Improved figure caption