### PR TITLE
fixed critical bug, scale_reads - no value in  / divided by …

### DIFF
--- a/bin/scale_reads.pl
+++ b/bin/scale_reads.pl
@@ -327,7 +327,7 @@ my %refs;
 
 my $c;
 my $tlen_sum; 
-my $seqwithtlen;
+my $seqwithtlen = 0;
 
 
 while(my $aln = $sp->next_aln()){
@@ -389,7 +389,8 @@ $closest_ref = (sort{$refs{$b} <=> $refs{$a}}keys %refs)[0];
 print "coverage\t", $current_cov, "\n";
 print "genome_size\t", $genome_size, "\n";
 print "target_coverage\t", $opt{target_coverage}, "\n";
-print "insert_size\t", int($tlen_sum/$seqwithtlen), "\n";
+if ($seqwithtlen > 0){ print "insert_size\t", int($tlen_sum/$seqwithtlen), "\n";}
+else {print "insert_size\tNA\n";}
 print "closest_ref\t", $closest_ref || 'NA', "\n";
 
 


### PR DESCRIPTION
10 / 11 data set died with the message 

```
Reading seed kmers
Reading total kmers
Plotting seed and total kmers
Use of uninitialized value $seqwithtlen in division (/) at /opt/chloroExtractor/bin/scale_reads.pl line 392, <R> line 10.
Use of uninitialized value $tlen_sum in division (/) at /opt/chloroExtractor/bin/scale_reads.pl line 392, <R> line 10.
Illegal division by zero at /opt/chloroExtractor/bin/scale_reads.pl line 392, <R> line 10.
```

Here the fix for it, the var was not initialized and when the insert size can't calculated it would die to this error.

Tested with 3 sets ( Demo set - allready worked, still works. And 2 sets where it died, now it finds several contigs but none complete chloroplast)